### PR TITLE
Use platform-specific path separator

### DIFF
--- a/MeddleTools/node_groups.py
+++ b/MeddleTools/node_groups.py
@@ -45,8 +45,8 @@ class PngMapping:
             print(f"Property {self.property_name} not found in material")
             return node_height - 300
         
-        
-        pathStr = properties[self.property_name]
+        pathStr = bpy.path.native_pathsep(properties[self.property_name])
+
         if pathStr is None or not isinstance(pathStr, str):
             print(f"Property {self.property_name} is not a string")
             return node_height - 300
@@ -235,7 +235,7 @@ class ColorSetMapping2:
         
         # spawn index texture
         texture = material.nodes.new('ShaderNodeTexImage')
-        pathStr = properties[self.index_texture_name]
+        pathStr = bpy.path.native_pathsep(properties[self.index_texture_name])
         if pathStr is None or not isinstance(pathStr, str):
             return node_height - 300
         
@@ -543,6 +543,8 @@ class BgMapping:
             if texture_name not in properties:
                 return None
             
+            pathStr = bpy.path.native_pathsep(properties[texture_name])
+
             if properties[texture_name] is None:
                 return None
             
@@ -553,11 +555,11 @@ class BgMapping:
             # if image loaded already, use that
             img = None
             for image in bpy.data.images:
-                if image.filepath == path.join(directory, properties[texture_name]):
+                if image.filepath == path.join(directory, pathStr):
                     img = image
                     break
             else:
-                img = bpy.data.images.load(path.join(directory, properties[texture_name]))
+                img = bpy.data.images.load(path.join(directory, pathStr))
                 
             texture = material.nodes.new('ShaderNodeTexImage')
             texture.image = img


### PR DESCRIPTION
When importing a gltf, for textures the addon simply joins the path that exists in the material custom properties. This path uses Windows-style path separators (`\`), which on Linux and Mac OS causes the file load to fail because it produces a path that looks something like `/home/user/meddle-export/cache/modded\abc\def\ghi\file.tex.png`. This basically results in a broken import where the user has to manually apply every texture to every relevant material and node.

This patch uses `bpy.path.native_pathsep` to convert these paths to whatever is appropriate. gltf imports then just work fine and textures are loaded properly.

(I'm super new to blender and python scripting so whatever I'm doing wrong or in a weird or inefficient way please point it out).