### PR TITLE
Color Space Consideration

### DIFF
--- a/MeddleTools/lighting.py
+++ b/MeddleTools/lighting.py
@@ -1,4 +1,5 @@
 import bpy
+from utils import helpers
 
 def setupLight(light: bpy.types.Object):
     if light is None:
@@ -13,7 +14,7 @@ def setupLight(light: bpy.types.Object):
             newLight = bpy.data.lights.new(name=light.name, type='SUN')
             newLight.energy = light["HDRIntensity"]
             rgbCol = light["ColorRGB"]
-            newLight.color = [rgbCol["X"], rgbCol["Y"], rgbCol["Z"]]
+            newLight.color = helpers.toBlenderColor([rgbCol["X"], rgbCol["Y"], rgbCol["Z"]], include_alpha=False)
             
             light.data = newLight  # replace the light data with the new one
             # set rotation to quaternion identity
@@ -27,7 +28,7 @@ def setupLight(light: bpy.types.Object):
             newLight.size = light["ShadowNear"]
             newLight.energy = light["HDRIntensity"]
             rgbCol = light["ColorRGB"]
-            newLight.color = [rgbCol["X"], rgbCol["Y"], rgbCol["Z"]]                   
+            newLight.color = helpers.toBlenderColor([rgbCol["X"], rgbCol["Y"], rgbCol["Z"]], include_alpha=False)                   
             newLight.use_custom_distance = True
             newLight.cutoff_distance = light["Range"]
             lightData.use_shadow = False

--- a/MeddleTools/lighting.py
+++ b/MeddleTools/lighting.py
@@ -1,5 +1,5 @@
 import bpy
-from utils import helpers
+from .utils import helpers
 
 def setupLight(light: bpy.types.Object):
     if light is None:

--- a/MeddleTools/node_setup/node_mappings.py
+++ b/MeddleTools/node_setup/node_mappings.py
@@ -5,6 +5,7 @@ import os.path as path
 import re
 import logging
 from typing import Callable, List, Tuple, Union, Any
+from ..utils import helpers
 
 logger = logging.getLogger(__name__)
 try:
@@ -29,11 +30,7 @@ class ColorMapping:
         
         group_input = group_node.inputs[self.field_name]
         if group_input.type == 'RGBA':
-            # pad to 4 values
-            if len(prop_value) == 3:
-                prop_value = (*prop_value, 1.0)
-            if len(prop_value) == 4:
-                group_input.default_value = prop_value
+            group_input.default_value = helpers.toBlenderColor(prop_value)
         else:
             logger.debug("Unsupported field type %s for %s", group_input.type, self.field_name)
 
@@ -55,6 +52,7 @@ class ColorHdrMapping:
             logger.debug("Field %s not found in group node inputs.", self.field_magnitude)
             return
         
+        prop_value = helpers.toBlenderColor(prop_value) # Unsure how the HDR stuff works but I'm guessing here would be an OK place to to colorspace corrections?
         field_input = group_node.inputs[self.field_name]
         field_magnitude_input = group_node.inputs[self.field_magnitude]
         
@@ -300,7 +298,7 @@ class ColorTableRampLookup:
             pos = i / len(set)
             if self.rowPropName not in row:
                 raise Exception(f"Row property {self.rowPropName} not found in row")
-            row_values = padRgbaValues(getValuesForType(row, self.rowPropName, self.rowPropType))
+            row_values = helpers.toBlenderColor(getValuesForType(row, self.rowPropName, self.rowPropType))
             if i == 0:
                 colorRamp.color_ramp.elements[0].position = pos
                 colorRamp.color_ramp.elements[0].color = row_values
@@ -333,7 +331,7 @@ class PackedColorTableRampLookup:
                 values = getValuesForType(row, rowPropName, rowPropType)
                 for val in values:
                     row_values.append(val)
-            row_values = padRgbaValues(row_values)
+            row_values = helpers.toBlenderColor(row_values)
             try:
                 if i == 0:
                     colorRamp.color_ramp.elements[0].position = i / len(set)

--- a/MeddleTools/utils/helpers.py
+++ b/MeddleTools/utils/helpers.py
@@ -85,18 +85,36 @@ def toBlenderColor(color_values:list[float], include_alpha:bool=True) -> tuple[f
     Returns:
         tuple[float, float, float, float]: A tuple consisting of R, G, B and A, converted to scene linear colors. Ready to feed to a Color Ramp or similar. A can be disabled with include_alpha=False.
     """
+    # It's possible we don't get a list, but an IDPropertyArray or something which does not have .pop(), but it can be converted to a list easily.
+    if not hasattr(color_values, 'pop') and hasattr(color_values, 'to_list'):
+        color_values = color_values.to_list()
+    else:
+        try:
+            list(color_values)
+        except:
+            logger.error(f"The function toBlenderColor got some object that it either isn't a list or it can't convert to a list: {color_values}. Returning a bright pink so it hopefully gets spotted and reported.")
+            if include_alpha:
+                return (1.0, 0.0, 1.0, 1.0)
+            else:
+                return (1.0, 0.0, 1.0)
+    
     num_values = len(color_values)
     alpha = 1.0
+    
     if num_values > 4:
         logger.warning(f"The function toBlenderColor was given a list of values longer than 4. Anything past that point will be trimmed away. Given list: {color_values}")
         color_values = color_values[:4]
+    
     if num_values == 4:
         # There's an alpha value which needs to be separated before colorspace conversion
         alpha = color_values.pop()
+    
     while len(color_values) < 3: # Unsure in which cases this would be needed, but just to be safe, make sure there are three color values
         color_values.append(1.0)
+    
     rec709_colors = mathutils.Color(color_values)
     working_space_colors = rec709_colors.from_rec709_linear_to_scene_linear()
+
     if include_alpha:
         return (working_space_colors.r, working_space_colors.g, working_space_colors.b, alpha)
     else:

--- a/MeddleTools/utils/helpers.py
+++ b/MeddleTools/utils/helpers.py
@@ -1,4 +1,12 @@
 import bpy
+import mathutils
+import logging
+
+logger = logging.getLogger(__name__)
+try:
+    logger.addHandler(logging.NullHandler())
+except Exception:
+    pass
 
 def safe_deselect_all_objects(context: bpy.types.Context):
     try:
@@ -66,3 +74,30 @@ def cleanup_imported_objects(imported_objects):
                 bpy.data.objects.remove(obj, do_unlink=True)
         except Exception:
             pass
+
+def toBlenderColor(color_values:list[float], include_alpha:bool=True) -> tuple[float, float, float, float]|tuple[float, float, float]:
+    """Converts a color in linear rec.709 to the format expected by Blender, in the working color space.
+
+    Args:
+        color_values (list[float]): List of values making up the rec.709 color. Four values -> RGBA. Will get padded or trimmed if it's too short/long.
+        include_alpha (bool, optional): Whether or not the output tuple should include the fourth value Alpha. Useful when assigning the color to things like lights. Defaults to True.
+
+    Returns:
+        tuple[float, float, float, float]: A tuple consisting of R, G, B and A, converted to scene linear colors. Ready to feed to a Color Ramp or similar. A can be disabled with include_alpha=False.
+    """
+    num_values = len(color_values)
+    alpha = 1.0
+    if num_values > 4:
+        logger.warning(f"The function toBlenderColor was given a list of values longer than 4. Anything past that point will be trimmed away. Given list: {color_values}")
+        color_values = color_values[:4]
+    if num_values == 4:
+        # There's an alpha value which needs to be separated before colorspace conversion
+        alpha = color_values.pop()
+    while len(color_values) < 3: # Unsure in which cases this would be needed, but just to be safe, make sure there are three color values
+        color_values.append(1.0)
+    rec709_colors = mathutils.Color(color_values)
+    working_space_colors = rec709_colors.from_rec709_linear_to_scene_linear()
+    if include_alpha:
+        return (working_space_colors.r, working_space_colors.g, working_space_colors.b, alpha)
+    else:
+        return (working_space_colors.r, working_space_colors.g, working_space_colors.b)


### PR DESCRIPTION
## The Issue
Blender 5.0 added support for changing the Working Color Space to something other than Linear Rec.709, but this apparently needs to be handled by addons that do color-stuff.
Currently if you import something using Meddle while using a color space other than linear rec.709 (which is the format used by most applications, including XIV), your colors will look incorrect with a severity ranging from "barely noticeable" to "extremely noticeable". A workaround is importing as rec.709 and then converting your scene to rec.2020, but that's annoying.

## Proposed Solution
Blender's built-in color format which you can get in `mathutils` comes with the function `from_rec709_linear_to_scene_linear()`, which does exactly what we need and seems to have been around for a long time (so this shouldn't break anything in older versions, tested it in 4.5.9LTS and it worked). By converting colors to this format before assigning them to wherever it is they need to be assigned, they'll look correct in other color spaces too!

## Example
**In both examples below the images from left to right are as follows:**
Current MeddleTools, character imported with Rec.709 _(the baseline)_
Current MeddleTools, character imported with Rec.2020 _(the problem)_
Current MeddleTools, character imported with Rec.709, then converted to Rec.2020 _(the workaround)_
This PR of MeddleTools, character imported with Rec.2020 _(no workaround needed)_

---
<img width="2880" height="720" alt="MeddleColorspace_Example2" src="https://github.com/user-attachments/assets/b0fad6de-1db4-4ea9-a082-c14a41bd1a26" />
Here the issue is pretty clear, the skin color and metals are extremely oversaturated.

---

<img width="2880" height="720" alt="MeddleColorspace_Example1" src="https://github.com/user-attachments/assets/d14ed9b6-2b7c-43e7-b6b4-61c967518cb9" />
Here it's more subtle, it's easiest to spot on the purple of the tail which got oversaturated. The skin is also a little bit too gray. The Rec.2020 version in both cases looks darker here, which is just due to how Blender is approximating the color-conversion. 

---

It's entirely possible that I missed colors being applied somewhere, or some change here is made in error (for example the HDR workflow, idk how that works) (I also haven't tested it with lights beyond knowing that the color has to only have three components).